### PR TITLE
Fix: outlet size 수정

### DIFF
--- a/frontend/src/pages/Layout.jsx
+++ b/frontend/src/pages/Layout.jsx
@@ -6,8 +6,10 @@ import Footer from '../components/Footer/Footer';
 
 const Body = styled.div`
 	display: flex;
-	padding: 0;
 	justify-content: center;
+`;
+const OutletSize = styled.div`
+	width: 1100px;
 `;
 const Layout = () => {
 	return (
@@ -15,7 +17,9 @@ const Layout = () => {
 			<Header />
 			<Body>
 				<LeftSideBar />
-				<Outlet />
+				<OutletSize>
+					<Outlet />
+				</OutletSize>
 			</Body>
 			<Footer />
 		</>


### PR DESCRIPTION
Layout 페이지의 body 안의 outlet 사이즈를 1100px로 고정하여 해상도가 달라지면 양옆에 공백이 추가되게 수정